### PR TITLE
Remove attestation period configuration

### DIFF
--- a/cmd/server/openstack_iid_attestor/main_test.go
+++ b/cmd/server/openstack_iid_attestor/main_test.go
@@ -10,13 +10,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/spiffe/spire/proto/common/plugin"
-
 	"github.com/zlabjp/spire-openstack-plugin/pkg/openstack"
 	"github.com/zlabjp/spire-openstack-plugin/pkg/util/fake"
 )
@@ -24,7 +21,6 @@ import (
 const (
 	testUUID      = "123"
 	testProjectID = "abc"
-	testPeriod    = "1h"
 
 	pluginConfig = `
 	cloud_name = "test"
@@ -99,30 +95,6 @@ func TestConfigureEmptyProjectID(t *testing.T) {
 	}
 }
 
-func TestConfigureInvalidPeriodValue(t *testing.T) {
-	p := newTestPlugin()
-	p.getInstanceHandler = func(n string) (openstack.InstanceClient, error) {
-		return fake.NewInstance(testProjectID, nil, nil), nil
-	}
-
-	conf := `
-	cloud_name = "test"
-	projectid_whitelist = ["alpha", "bravo"]
-	attestation_period = "invalid"
-	`
-
-	ctx := context.Background()
-	req := fake.NewFakeConfigureRequest(globalConfig, conf)
-
-	wantErrorPrefix := "invalid value for attestation_period"
-	_, err := p.Configure(ctx, req)
-	if err == nil {
-		t.Error("expected error, got nil")
-	} else if !strings.HasPrefix(err.Error(), wantErrorPrefix) {
-		t.Errorf("got %v, wantPrefix %v", err, wantErrorPrefix)
-	}
-}
-
 func TestAttest(t *testing.T) {
 	fi := fake.NewInstance(testProjectID, nil, nil)
 
@@ -182,26 +154,5 @@ func TestAttestBefore(t *testing.T) {
 		t.Errorf("an error expectd, got nil")
 	} else if err.Error() != fmt.Sprintf("the IID has been used and is no longer valid: %v", testUUID) {
 		t.Errorf("unexpected error messsage: %v", err)
-	}
-}
-
-func TestAttestPeriod(t *testing.T) {
-	fi := fake.NewInstanceWithTime(testProjectID, time.Now().Add(-time.Second*6000))
-	period, err := time.ParseDuration(testPeriod)
-	if err != nil {
-		t.Errorf("error before testing: %v", err)
-	}
-
-	p := newTestPlugin()
-	p.instance = fi
-	p.config.ProjectIDWhitelist = []string{testProjectID}
-	p.period = time.Duration(period)
-
-	fs := fake.NewAttestStream(testUUID, false)
-
-	if err := p.Attest(fs); err == nil {
-		t.Errorf("an error expectd, got nil")
-	} else if err.Error() != "attestation period has expired" {
-		t.Errorf("unexpected error message: %v", err)
 	}
 }

--- a/doc/openstack-iid-attestor.md
+++ b/doc/openstack-iid-attestor.md
@@ -28,7 +28,6 @@ plugins {
         plugin_data {
             cloud_name = "test"
             projectid_whitelist = ["123", "abc"]
-            attestation_period = "5m"
         }
     }
 ...
@@ -38,7 +37,6 @@ plugins {
 |:----|:-----|:---------|:------------|:--------|
 | cloud_name | string | ✓ | Name of cloud entry in clouds.yaml to use |  |
 | projectid_whitelist | array | ✓ | List of authorized ProjectIDs | |
-|attestation_period | string | | If specified, an attestation request must be made within this time period. | 5m (Go-style time duration) |
 
 The plugin_name should be "openstack_iid" and matches the name used in plugin config. The plugin_cmd should specify the path to the plugin binary.
 
@@ -68,7 +66,7 @@ The plugin_name should be "openstack_iid" and matches the name used in plugin co
 ## Security Consideration
 
 At this time OpenStack doesn't have signature for Identity information like AWS Instance Identity Documents or GCP Instance Identity Token. Therefore, Server can't prevent spoofing by a malicious Agent.
-As a mitigation measure, re-attestation of the same instance is prohibited, and we can set the period from instance startup to attestation request.
+As a mitigation measure, re-attestation of the same instance is prohibited.
 In the future, if it is possible to acquire more information that can attest the agent from OpenStack or Plugin feature, it is possible to more strictly identify the agent.
 For instance, in the Server Plugin, it is conceivable to compare the IP address of the request source with the IP address associated with the instance obtainable from the instance metadata.
 


### PR DESCRIPTION
This PR removes 'attestaion-period' parameter from attestor configuraion.
It does not make sense,  if the agent wants to re-attestaion such as when agent process was down.