### PR TITLE
Fix 404 error link

### DIFF
--- a/doc/openstack-iid-resolver.md
+++ b/doc/openstack-iid-resolver.md
@@ -15,10 +15,6 @@ The `openstack_iid` resolver plugin resolves OpenStack IID-based SPIFFE ID into 
 
  [^1]: https://developer.openstack.org/api-guide/compute/server_concepts.html#server-metadata
 
-## Diagram
-
-![diagram](images/plugin-diagram.png)
-
 ## Configuration
 
 | key | type | required | description | default |


### PR DESCRIPTION
Fix 404 link. 
Since the diagram is linked in README.md, no longer need it.