### PR TITLE
No longer support Go 1.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Go 1.11 or higher
+- Go 1.12 or higher
 
 ## Building
 


### PR DESCRIPTION
Supports Go 1.12 or higher.

